### PR TITLE
Add .gitignore for Python artifacts and PDF files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.pdf


### PR DESCRIPTION
## Summary
- add a .gitignore to exclude Python build artifacts
- ignore generated PDF files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68833c49ef44832082a19580b31ec1d5