### PR TITLE
Allow custom book and chapter count

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ set. Optionally define `OPENAI_MODEL` if you want to use a different model.
 Run the script with Python:
 
 ```bash
-python generate_john.py
+python generate_john.py --book john --chapters 21
 ```
 
-The script will create one PDF per verse in the current directory.
+The `--book` and `--chapters` options are optional; they default to `john` and
+`21` respectively. The script will create one PDF per verse in the specified
+book and chapter range.

--- a/generate_john.py
+++ b/generate_john.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import time
+import argparse
 import requests
 import openai
 from reportlab.lib.pagesizes import letter
@@ -83,4 +84,20 @@ def generate_book(book: str, chapters: int):
 
 
 if __name__ == "__main__":
-    generate_book("john", 21)
+    parser = argparse.ArgumentParser(
+        description="Generate word-study PDFs for a book of the Bible"
+    )
+    parser.add_argument(
+        "--book",
+        default="john",
+        help="Name of the book to process (default: john)",
+    )
+    parser.add_argument(
+        "--chapters",
+        type=int,
+        default=21,
+        help="Number of chapters in the book",
+    )
+    args = parser.parse_args()
+
+    generate_book(args.book, args.chapters)


### PR DESCRIPTION
## Summary
- add argparse to parse command-line arguments
- update default CLI usage in README

## Testing
- `python -m py_compile generate_john.py`

------
https://chatgpt.com/codex/tasks/task_e_68833e91b02c832095c95946f2a4ca56