### PR TITLE
Apply DOMPurify sanitization for entry HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ curl -I http://localhost:8000/index.html
 
 The command should return an HTTP `200` response. Press `Ctrl+C` in the terminal
 running `http.server` when you are done.
+
+## HTML Sanitization
+
+The viewer sanitizes entry snippets using [DOMPurify](https://github.com/cure53/DOMPurify) before inserting them into the page.
+Only basic formatting tags like `<b>` and `<i>` are allowed. If existing JSON
+files rely on stripped tags, remove or rewrite those elements in the JSON so the
+sanitized output matches your expectations. Reload `index.html` locally after
+each change to verify the rendered result.

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     </div>
   </div>
 
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/2.4.0/purify.min.js" integrity="sha384-Tsl3d5pUAO7a13enIvSsL3O0/95nsthPJiPto5NtLuY8w3+LbZOpr3Fl2MNmrh1E" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -10,12 +10,17 @@ async function loadData() {
   // Map of Greek word -> entry HTML
   const entryMap = {};
   data.entries.forEach(raw => {
+    // Sanitize the HTML snippet to remove potentially dangerous tags
+    const safe = DOMPurify.sanitize(raw, {
+      ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'u', 'br']
+    });
+
     const div = document.createElement('div');
-    div.innerHTML = raw;
+    div.innerHTML = safe;
     const bold = div.querySelector('b');
     if (bold) {
       const key = bold.textContent.trim();
-      entryMap[key] = div.innerHTML; // store the html snippet
+      entryMap[key] = div.innerHTML; // store the sanitized snippet
     }
   });
 


### PR DESCRIPTION
## Summary
- sanitize entry HTML with DOMPurify when building the entry map
- pull in DOMPurify via CDN
- add documentation on HTML sanitization and updating JSON

## Testing
- `node -e "const fs=require('fs');const data=JSON.parse(fs.readFileSync('data/example.json'));console.log(Object.keys(data));"`
- `python3 -m http.server >/tmp/server.log 2>&1 &` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_688d345ac9408320b004dd7afa9e5386