### PR TITLE
Add manifest and reference selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Serve the site locally using Python's built-in HTTP server and open `index.html`
 python3 -m http.server
 ```
 
-The page loads `data/example.json` and highlights rows that have matching entries. Click a highlighted row to view additional information.
+The page loads `data/index.json` which lists available chapter/verse files. Choose a reference from the drop-down to load its table and entries.
 
 ## Quick Start (macOS)
 
@@ -55,3 +55,11 @@ Only basic formatting tags like `<b>` and `<i>` are allowed. If existing JSON
 files rely on stripped tags, remove or rewrite those elements in the JSON so the
 sanitized output matches your expectations. Reload `index.html` locally after
 each change to verify the rendered result.
+
+## Maintaining the Manifest
+
+All study data files live in the `data` directory. The `data/index.json`
+manifest lists the available chapters so the drop-down on the page can be
+populated. When you add a new JSON file, include an object in the manifest with
+its filename and a human‑readable title. The viewer will then offer it as a
+selectable reference.

--- a/data/index.json
+++ b/data/index.json
@@ -1,0 +1,5 @@
+{
+  "references": [
+    {"file": "example.json", "title": "Matthew 13:54"}
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
 </head>
 <body>
   <div class="container">
+    <label for="ref-select">Reference:</label>
+    <select id="ref-select"></select>
     <h1 id="title"></h1>
     <p id="context" class="context"></p>
     <h2 id="subtitle"></h2>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
-async function loadData() {
-  const response = await fetch('data/example.json');
+async function loadData(file) {
+  const response = await fetch(`data/${file}`);
   const data = await response.json();
 
   document.getElementById('title').textContent = data.title;
@@ -61,4 +61,24 @@ document.getElementById('close-btn').addEventListener('click', () => {
   document.getElementById('overlay').classList.add('hidden');
 });
 
-document.addEventListener('DOMContentLoaded', loadData);
+async function init() {
+  const indexRes = await fetch('data/index.json');
+  const manifest = await indexRes.json();
+
+  const select = document.getElementById('ref-select');
+  manifest.references.forEach(ref => {
+    const option = document.createElement('option');
+    option.value = ref.file;
+    option.textContent = ref.title;
+    select.appendChild(option);
+  });
+
+  select.addEventListener('change', () => loadData(select.value));
+
+  if (manifest.references.length > 0) {
+    select.value = manifest.references[0].file;
+    loadData(select.value);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- create `data/index.json` listing available data files
- fetch manifest in new `init()` function and populate a drop-down selector
- update `loadData()` to load the selected file
- expose the selector in `index.html`
- document how to maintain the manifest

## Testing
- `python3 -m json.tool data/index.json`


------
https://chatgpt.com/codex/tasks/task_e_688d352aefac83208805d81a67e50746