### PR TITLE
Add searchable reference list

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,10 @@
 </head>
 <body>
   <div class="container">
-    <label for="ref-select">Reference:</label>
-    <select id="ref-select"></select>
+    <input id="search" type="text" placeholder="Search reference...">
+    <ul id="ref-list"></ul>
+    <label for="ref-select" class="hidden">Reference:</label>
+    <select id="ref-select" class="hidden"></select>
     <button id="prev-btn">Previous</button>
     <button id="next-btn">Next</button>
     <h1 id="title"></h1>

--- a/script.js
+++ b/script.js
@@ -79,12 +79,21 @@ document.getElementById('close-btn').addEventListener('click', () => {
   document.getElementById('overlay').classList.add('hidden');
 });
 
+function highlightSelected(file) {
+  document.querySelectorAll('#ref-list li').forEach(li => {
+    li.classList.toggle('selected', li.dataset.file === file);
+  });
+  const select = document.getElementById('ref-select');
+  select.value = file;
+}
+
 function changeReference(offset) {
   const select = document.getElementById('ref-select');
   const idx = references.findIndex(r => r.file === select.value);
   const nextIndex = idx + offset;
   if (nextIndex >= 0 && nextIndex < references.length) {
     select.value = references[nextIndex].file;
+    highlightSelected(select.value);
     loadData(select.value);
   }
 }
@@ -98,20 +107,36 @@ async function init() {
 
   references = sortRefs(manifest.references);
 
+  const list = document.getElementById('ref-list');
   const select = document.getElementById('ref-select');
+
   references.forEach(ref => {
+    const li = document.createElement('li');
+    li.textContent = ref.title;
+    li.dataset.file = ref.file;
+    li.addEventListener('click', () => {
+      highlightSelected(ref.file);
+      loadData(ref.file);
+    });
+    list.appendChild(li);
+
     const option = document.createElement('option');
     option.value = ref.file;
     option.textContent = ref.title;
     select.appendChild(option);
   });
 
-  select.addEventListener('change', () => loadData(select.value));
+  document.getElementById('search').addEventListener('input', e => {
+    const q = e.target.value.toLowerCase();
+    list.querySelectorAll('li').forEach(li => {
+      li.style.display = li.textContent.toLowerCase().includes(q) ? '' : 'none';
+    });
+  });
 
-  if (references.length > 0) {
-    select.value = references[0].file;
+  select.addEventListener('change', () => {
+    highlightSelected(select.value);
     loadData(select.value);
-  }
+  });
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/style.css
+++ b/style.css
@@ -8,6 +8,10 @@ body {
   padding: 1rem;
 }
 
+.hidden {
+  display: none;
+}
+
 .context {
   font-style: italic;
   margin-bottom: 1rem;
@@ -53,6 +57,21 @@ body {
   overflow-y: auto;
   max-height: 80vh;
   position: relative;
+}
+
+#ref-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+}
+
+#ref-list li {
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+#ref-list li.selected {
+  background-color: #e0e0e0;
 }
 
 #close-btn {


### PR DESCRIPTION
## Summary
- show a search box and list of references on the landing page
- filter references while typing
- call `loadData()` when a list item is chosen
- keep previous/next controls working via hidden select

## Testing
- `python3 -m http.server 8000` and `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_688d36f793208320bab811c094c12a10