### PR TITLE
Improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This project provides a simple static website that renders word-by-word study JS
 
 ## Development
 
-Serve the site locally using Python's built-in HTTP server and open `index.html` in your browser:
+Serve the site locally using Python's built‑in HTTP server and open `index.html` in your browser:
 
 ```bash
 python3 -m http.server
 ```
 
-The page loads `data/index.json` which lists available chapter/verse files. Choose a reference from the drop-down to load its table and entries.
+The page loads `data/index.json` which lists available chapter/verse files. Choose a reference from the drop‑down to load its table and entries.
 
 ## Quick Start (macOS)
 
@@ -48,6 +48,13 @@ curl -I http://localhost:8000/index.html
 The command should return an HTTP `200` response. Press `Ctrl+C` in the terminal
 running `http.server` when you are done.
 
+## Navigation and Search
+
+The reference list appears on the left. Use the search box to filter the list by
+book, chapter, or verse. Clicking a reference loads its data. You can also move
+through the list sequentially with the **Previous** and **Next** buttons.
+
+
 ## HTML Sanitization
 
 The viewer sanitizes entry snippets using [DOMPurify](https://github.com/cure53/DOMPurify) before inserting them into the page.
@@ -59,7 +66,30 @@ each change to verify the rendered result.
 ## Maintaining the Manifest
 
 All study data files live in the `data` directory. The `data/index.json`
-manifest lists the available chapters so the drop-down on the page can be
-populated. When you add a new JSON file, include an object in the manifest with
-its filename and a human‑readable title. The viewer will then offer it as a
-selectable reference.
+manifest lists the available chapters so the drop‑down and sidebar can be
+populated. Each entry has a `file` pointing to a verse JSON and a `title`
+displayed in the UI:
+
+```json
+{
+  "references": [
+    {"file": "Matthew-13-56.json", "title": "Matthew 13:56"}
+  ]
+}
+```
+
+To add another passage:
+
+1. Create a new JSON file in `data/` following the same structure as the
+   existing ones (`context`, `title`, `subtitle`, `table`, `entries`, `source`).
+2. Append an object for the file to `data/index.json`.
+
+The viewer sorts entries automatically, so the order in the manifest does not
+matter. Reload the page after saving to see the new verse in the list.
+
+## Serving and Hosting
+
+Any static file server can host the viewer. During development `python3 -m
+http.server` is convenient. For production you can upload the contents of this
+repository to services such as GitHub Pages, Netlify, or any web server capable
+of serving static files.


### PR DESCRIPTION
## Summary
- document navigation and search features
- expand manifest instructions and detail how to add new verse JSONs
- add information on hosting the site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d3922cc108320836ca88806aa28d5