### PR TITLE
docs: update README for Sanity-powered content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Word Study Viewer
 
-This project provides a simple static website that renders word-by-word study JSON files in a mobile-friendly layout.
+This project provides a simple static website that renders word-by-word study data from a Sanity CMS in a mobile-friendly layout.
 
 ## Development
 
@@ -10,12 +10,11 @@ Serve the site locally using Python's built‑in HTTP server and open `index.htm
 python3 -m http.server
 ```
 
-The page loads `data/index.json` which lists available chapter/verse files. Choose a reference from the drop‑down to load its table and entries.
+All verse data is fetched at runtime from your Sanity dataset. Populate the CMS and set `SANITY_PROJECT_ID`, `SANITY_DATASET`, and `SANITY_API_VERSION` in `sanityClient.js` or export them in your environment before launching the server. With valid credentials the page lists available references; choose one to load its table and entries.
 
 ## Quick Start (macOS)
 
-The project has no build step or external dependencies. The commands below can be
-copied directly into a macOS terminal to view the site locally.
+The project has no build step or external dependencies. The commands below can be copied directly into a macOS terminal to view the site locally.
 
 ```bash
 # Install Python 3 if it's not already available
@@ -27,6 +26,11 @@ git clone https://github.com/yourusername/alpha-omega.git
 # Navigate to the project directory
 cd alpha-omega
 
+# Provide your Sanity credentials (or edit sanityClient.js)
+export SANITY_PROJECT_ID=your_project_id
+export SANITY_DATASET=production
+export SANITY_API_VERSION=2023-10-01
+
 # Start a local development server
 python3 -m http.server
 
@@ -34,8 +38,7 @@ python3 -m http.server
 open http://localhost:8000
 ```
 
-You should now see the Word Study Viewer in your browser. Click any highlighted
-row to open a detailed entry overlay.
+You should now see the Word Study Viewer in your browser. Click any highlighted row to open a detailed entry overlay.
 
 ### Verify the server is running
 
@@ -45,51 +48,23 @@ With the server active you can check that files are being served correctly:
 curl -I http://localhost:8000/index.html
 ```
 
-The command should return an HTTP `200` response. Press `Ctrl+C` in the terminal
-running `http.server` when you are done.
+The command should return an HTTP `200` response. Press `Ctrl+C` in the terminal running `http.server` when you are done.
 
 ## Navigation and Search
 
-The reference list appears on the left. Use the search box to filter the list by
-book, chapter, or verse. Clicking a reference loads its data. You can also move
-through the list sequentially with the **Previous** and **Next** buttons.
-
+The reference list appears on the left. Use the search box to filter the list by book, chapter, or verse. Clicking a reference loads its data from Sanity. You can also move through the list sequentially with the **Previous** and **Next** buttons.
 
 ## HTML Sanitization
 
-The viewer sanitizes entry snippets using [DOMPurify](https://github.com/cure53/DOMPurify) before inserting them into the page.
-Only basic formatting tags like `<b>` and `<i>` are allowed. If existing JSON
-files rely on stripped tags, remove or rewrite those elements in the JSON so the
-sanitized output matches your expectations. Reload `index.html` locally after
-each change to verify the rendered result.
+The viewer sanitizes entry snippets using [DOMPurify](https://github.com/cure53/DOMPurify) before inserting them into the page. Only basic formatting tags like `<b>` and `<i>` are allowed. If entries in the CMS rely on stripped tags, remove or rewrite those elements in Sanity so the sanitized output matches your expectations. Reload `index.html` locally after each change to verify the rendered result.
 
-## Maintaining the Manifest
+## Sanity Setup
 
-All study data files live in the `data` directory. The `data/index.json`
-manifest lists the available chapters so the drop‑down and sidebar can be
-populated. Each entry has a `file` pointing to a verse JSON and a `title`
-displayed in the UI:
-
-```json
-{
-  "references": [
-    {"file": "Matthew-13-56.json", "title": "Matthew 13:56"}
-  ]
-}
-```
-
-To add another passage:
-
-1. Create a new JSON file in `data/` following the same structure as the
-   existing ones (`context`, `title`, `subtitle`, `table`, `entries`, `source`).
-2. Append an object for the file to `data/index.json`.
-
-The viewer sorts entries automatically, so the order in the manifest does not
-matter. Reload the page after saving to see the new verse in the list.
+1. Create a Sanity project and dataset. The [Sanity CLI](https://www.sanity.io/docs/getting-started) can initialize a new project.
+2. Define a `reference` schema with a `slug` (used as the file name) and `title`. Include fields for `context`, `table`, and `entries` to store the passage content.
+3. Note your project ID, dataset name, and preferred API version.
+4. Set `SANITY_PROJECT_ID`, `SANITY_DATASET`, and `SANITY_API_VERSION` in `sanityClient.js` or supply them via environment variables before serving the site.
 
 ## Serving and Hosting
 
-Any static file server can host the viewer. During development `python3 -m
-http.server` is convenient. For production you can upload the contents of this
-repository to services such as GitHub Pages, Netlify, or any web server capable
-of serving static files.
+Any static file server can host the viewer. During development `python3 -m http.server` is convenient. For production you can upload the contents of this repository to services such as GitHub Pages, Netlify, or any web server capable of serving static files.


### PR DESCRIPTION
## Summary
- document Sanity project setup and schema definitions
- note that development still uses `python3 -m http.server` but data comes from the CMS
- remove instructions about editing local JSON files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d9981c95c8320b130ed700cb815bd