### PR TITLE
Add Sanity schemas and align client queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The viewer sanitizes entry snippets using [DOMPurify](https://github.com/cure53/
 ## Sanity Setup
 
 1. Create a Sanity project and dataset. The [Sanity CLI](https://www.sanity.io/docs/getting-started) can initialize a new project.
-2. Define a `reference` schema with a `slug` (used as the file name) and `title`. Include fields for `context`, `table`, and `entries` to store the passage content.
+2. Define a `reference` schema with a `title` and auto‑generated `slug` and a `verse` schema that references a `reference` and holds the `context`, `subtitle`, `source`, `table`, and HTML `entries` for that passage. Example schema files and starter documents live in the `sanity` folder of this repo.
 3. Note your project ID, dataset name, and preferred API version.
 4. Set `SANITY_PROJECT_ID`, `SANITY_DATASET`, and `SANITY_API_VERSION` in `sanityClient.js` or supply them via environment variables before serving the site.
 

--- a/sanity/sanity.config.js
+++ b/sanity/sanity.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'sanity';
+import { deskTool } from 'sanity/desk';
+import schemas from './schemas';
+
+export default defineConfig({
+  projectId: 'your_project_id',
+  dataset: 'production',
+  title: 'Alpha Omega Studio',
+  plugins: [deskTool()],
+  schema: {
+    types: schemas
+  }
+});

--- a/sanity/schemas/index.js
+++ b/sanity/schemas/index.js
@@ -1,0 +1,4 @@
+import reference from './reference';
+import verse from './verse';
+
+export default [reference, verse];

--- a/sanity/schemas/reference.js
+++ b/sanity/schemas/reference.js
@@ -1,0 +1,24 @@
+export default {
+  name: 'reference',
+  title: 'Reference',
+  type: 'document',
+  fields: [
+    {
+      name: 'title',
+      type: 'string',
+      title: 'Title'
+    },
+    {
+      name: 'slug',
+      type: 'slug',
+      title: 'Slug',
+      options: {
+        source: 'title',
+        slugify: input =>
+          input
+            .replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-]/g, '')
+            .toLowerCase()
+      }
+    }
+  ]
+};

--- a/sanity/schemas/verse.js
+++ b/sanity/schemas/verse.js
@@ -1,0 +1,45 @@
+export default {
+  name: 'verse',
+  title: 'Verse',
+  type: 'document',
+  fields: [
+    {
+      name: 'reference',
+      title: 'Reference',
+      type: 'reference',
+      to: [{ type: 'reference' }]
+    },
+    {
+      name: 'context',
+      type: 'string',
+      title: 'Context'
+    },
+    {
+      name: 'subtitle',
+      type: 'string',
+      title: 'Subtitle'
+    },
+    {
+      name: 'source',
+      type: 'string',
+      title: 'Source'
+    },
+    {
+      name: 'table',
+      title: 'Table',
+      type: 'array',
+      of: [
+        {
+          type: 'array',
+          of: [{ type: 'string' }]
+        }
+      ]
+    },
+    {
+      name: 'entries',
+      title: 'Entries',
+      type: 'array',
+      of: [{ type: 'text' }]
+    }
+  ]
+};

--- a/sanity/seed/initial-documents.json
+++ b/sanity/seed/initial-documents.json
@@ -1,0 +1,25 @@
+[
+  {
+    "_id": "reference-matthew-13-54",
+    "_type": "reference",
+    "title": "Matthew 13:54",
+    "slug": { "_type": "slug", "current": "Matthew-13-54" }
+  },
+  {
+    "_id": "verse-matthew-13-54",
+    "_type": "verse",
+    "reference": { "_type": "reference", "_ref": "reference-matthew-13-54" },
+    "context": "Coming to his hometown, he began teaching the people in their synagogue...",
+    "subtitle": "A Prophet Without Honor",
+    "source": "NIV",
+    "table": [
+      ["Greek", "Transliteration", "Meaning"],
+      ["\u03C0\u03B1\u03C1\u03B1\u03B2\u03BF\u03BB\u03AE", "parabol\u0113", "parable"],
+      ["\u03B4\u03B9\u03B4\u03AC\u03C3\u03BA\u03C9", "didask\u014D", "teach"]
+    ],
+    "entries": [
+      "<b>\u03C0\u03B1\u03C1\u03B1\u03B2\u03BF\u03BB\u03AE</b> - parable or proverb",
+      "<b>\u03B4\u03B9\u03B4\u03AC\u03C3\u03BA\u03C9</b> - to teach or instruct"
+    ]
+  }
+]

--- a/sanityClient.js
+++ b/sanityClient.js
@@ -14,7 +14,7 @@ export async function fetchReferenceList() {
 }
 
 export async function fetchReferenceData(slug) {
-  const query = '*[_type=="reference" && slug.current == $slug][0]{ title, context, subtitle, source, table, entries }';
+  const query = '*[_type=="verse" && reference->slug.current == $slug][0]{"title": reference->title, context, subtitle, source, table, entries }';
   const url = `${BASE_URL}?query=${encodeURIComponent(query)}&$slug=${encodeURIComponent(slug)}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error('request failed');


### PR DESCRIPTION
## Summary
- define Sanity `reference` and `verse` document schemas with starter content
- seed example `Matthew-13-54` documents and expose studio config
- update GROQ query to read verse data via referenced reference document
- clarify setup steps for the new schema structure

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688de75dec44832088baa152258e446f