### PR TITLE
Handle content service errors

### DIFF
--- a/sanityClient.js
+++ b/sanityClient.js
@@ -5,19 +5,31 @@ const BASE_URL = `https://${SANITY_PROJECT_ID}.api.sanity.io/v${SANITY_API_VERSI
 export async function fetchReferenceList() {
   const query = '*[_type=="reference"]{ "file": slug.current, title }';
   const url = `${BASE_URL}?query=${encodeURIComponent(query)}`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error('request failed');
-  const { result } = await res.json();
-  return { references: result || [] };
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`request failed with status ${res.status}`);
+    }
+    const { result } = await res.json();
+    return { references: result || [] };
+  } catch (err) {
+    throw new Error(`fetchReferenceList: ${err.message}`);
+  }
 }
 
 export async function fetchReferenceData(slug) {
   const query = '*[_type=="verse" && reference->slug.current == $slug][0]{"title": reference->title, context, subtitle, source, table, entries }';
   const url = `${BASE_URL}?query=${encodeURIComponent(query)}&$slug=${encodeURIComponent(slug)}`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error('request failed');
-  const { result } = await res.json();
-  return result;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`request failed with status ${res.status}`);
+    }
+    const { result } = await res.json();
+    return result;
+  } catch (err) {
+    throw new Error(`fetchReferenceData: ${err.message}`);
+  }
 }
 
 export { SANITY_PROJECT_ID, SANITY_DATASET, SANITY_API_VERSION };

--- a/script.js
+++ b/script.js
@@ -82,7 +82,7 @@ async function loadData(file) {
       });
     });
   } catch (err) {
-    showError('Failed to load the selected reference.');
+    showError('Unable to contact content service.');
     document.getElementById('word-table').innerHTML = '';
     document.getElementById('title').textContent = '';
     document.getElementById('context').textContent = '';
@@ -126,19 +126,20 @@ document.getElementById('prev-btn').addEventListener('click', () => changeRefere
 document.getElementById('next-btn').addEventListener('click', () => changeReference(1));
 
 async function init() {
+  const list = document.getElementById('ref-list');
+  const select = document.getElementById('ref-select');
   let manifest;
   try {
     manifest = await fetchReferenceList();
     clearError();
   } catch (err) {
-    showError('Failed to load reference list.');
+    showError('Unable to contact content service.');
+    list.innerHTML = '<li class="placeholder">No references available</li>';
+    select.innerHTML = '';
     return;
   }
 
   references = sortRefs(manifest.references);
-
-  const list = document.getElementById('ref-list');
-  const select = document.getElementById('ref-select');
 
   references.forEach(ref => {
     const li = document.createElement('li');


### PR DESCRIPTION
## Summary
- Wrap Sanity queries in try/catch and rethrow contextual errors.
- Show user-facing error messages when the content service can't be reached and provide a placeholder sidebar entry.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688de97821f083209cd512fbf2f638ba