### PR TITLE
Preserve line breaks in popup entries

### DIFF
--- a/script.js
+++ b/script.js
@@ -41,10 +41,11 @@ async function loadData(file) {
     document.getElementById('source').textContent = `Source: ${data.source}`;
 
   // Map of Greek word -> entry HTML
-    const entryMap = {};
-    data.entries.forEach(raw => {
-    // Sanitize the HTML snippet to remove potentially dangerous tags
-    const safe = DOMPurify.sanitize(raw, {
+  const entryMap = {};
+  data.entries.forEach(raw => {
+    // Replace newlines with <br> for display and sanitize the result
+    const withBreaks = raw.replace(/\n/g, '<br>');
+    const safe = DOMPurify.sanitize(withBreaks, {
       ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'u', 'br']
     });
 

--- a/style.css
+++ b/style.css
@@ -64,6 +64,10 @@ body {
   position: relative;
 }
 
+#entry-content {
+  white-space: pre-line;
+}
+
 #ref-list {
   list-style: none;
   padding: 0;


### PR DESCRIPTION
## Summary
- convert newline characters in entry data to `<br>` before sanitizing
- apply `white-space: pre-line` styling to entry content container to respect line breaks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688df99954548320b4d4b2e114d32fd8